### PR TITLE
🎮 GameY Bot API — `play` endpoint & gateway routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     image: mongo
     container_name: mongo
     restart: unless-stopped
-    ports:
-      - "27017:27017"
+    #ports:
+    #  - "27017:27017"
     volumes:
       - mongo-data:/data/db
     networks:
@@ -14,8 +14,8 @@ services:
     build: ./users
     container_name: users
     image: ghcr.io/arquisoft/yovi_en1c-users:latest
-    ports:
-      - "3000:3000"
+    #ports:
+    #  - "3000:3000"
     networks:
       - monitor-net
     environment:
@@ -43,8 +43,8 @@ services:
     build: ./gamey
     container_name: gamey
     image: ghcr.io/arquisoft/yovi_en1c-gamey:latest
-    ports:
-      - "4000:4000"
+    #ports:
+    #  - "4000:4000"
     networks:
       - monitor-net
 

--- a/gamey/src/bot_server/mod.rs
+++ b/gamey/src/bot_server/mod.rs
@@ -23,6 +23,7 @@ pub mod choose;
 pub mod error;
 pub mod state;
 pub mod version;
+pub mod play;
 use axum::response::IntoResponse;
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
@@ -42,6 +43,7 @@ pub fn create_router(state: AppState) -> axum::Router {
             "/{api_version}/ybot/choose/{bot_id}",
             axum::routing::post(choose::choose),
         )
+        .route("/{api_version}/play", axum::routing::post(play::play))
         .layer(CorsLayer::permissive())
         .with_state(state)
 }

--- a/gamey/src/bot_server/play.rs
+++ b/gamey/src/bot_server/play.rs
@@ -1,0 +1,91 @@
+use crate::{Coordinates, GameY, GameStatus, Movement, YEN, 
+            check_api_version, error::ErrorResponse, state::AppState};
+use axum::{Json, extract::{Path, State}};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct PlayParams {
+    pub api_version: String,
+}
+
+#[derive(Deserialize)]
+pub struct PlayRequest {
+    pub yen: YEN,
+    pub position: u32,
+    pub bot_id: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct PlayResponse {
+    pub api_version: String,
+    pub yen: YEN,
+    pub status: String,   // "ongoing" | "finished"
+    pub winner: Option<u32>,
+}
+
+#[axum::debug_handler]
+pub async fn play(
+    State(state): State<AppState>,
+    Path(params): Path<PlayParams>,
+    Json(body): Json<PlayRequest>,
+) -> Result<Json<PlayResponse>, Json<ErrorResponse>> {
+    check_api_version(&params.api_version)?;
+
+    let mut game = GameY::try_from(body.yen).map_err(|e| {
+        Json(ErrorResponse::error(
+            &format!("Invalid YEN: {}", e),
+            Some(params.api_version.clone()),
+            None,
+        ))
+    })?;
+
+    // Apply the human move
+    let next = game.next_player().ok_or_else(|| {
+        Json(ErrorResponse::error(
+            "Game is already over",
+            Some(params.api_version.clone()),
+            None,
+        ))
+    })?;
+
+    let coords = Coordinates::from_index(body.position, game.board_size());
+    game.add_move(Movement::Placement { player: next, coords })
+        .map_err(|e| Json(ErrorResponse::error(
+            &format!("Invalid move: {}", e),
+            Some(params.api_version.clone()),
+            None,
+        )))?;
+
+    // If bot_id provided and game still ongoing, bot plays
+    if let Some(bot_id) = &body.bot_id {
+        if !game.check_game_over() {
+            let bot = state.bots().find(bot_id).ok_or_else(|| {
+                Json(ErrorResponse::error(
+                    &format!("Bot not found: {}", bot_id),
+                    Some(params.api_version.clone()),
+                    Some(bot_id.clone()),
+                ))
+            })?;
+
+            if let Some(bot_coords) = bot.choose_move(&game) {
+                let bot_player = game.next_player().unwrap();
+                game.add_move(Movement::Placement {
+                    player: bot_player,
+                    coords: bot_coords,
+                }).ok();
+            }
+        }
+    }
+
+    let (status, winner) = match game.status() {
+        GameStatus::Finished { winner } => ("finished".to_string(), Some(winner.id())),
+        GameStatus::Ongoing { .. }      => ("ongoing".to_string(),  None),
+    };
+
+    Ok(Json(PlayResponse {
+        api_version: params.api_version,
+        yen: (&game).into(),
+        status,
+        winner,
+    }))
+}

--- a/gamey/tests/play_tests.rs
+++ b/gamey/tests/play_tests.rs
@@ -1,0 +1,436 @@
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use gamey::{YBotRegistry, YEN, create_default_state, create_router, state::AppState, RandomBot, ErrorResponse};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn test_app() -> axum::Router {
+    create_router(create_default_state())
+}
+
+fn empty_board_size3() -> YEN {
+    YEN::new(3, 0, vec!['B', 'R'], "./../...".to_string())
+}
+
+async fn post_play(app: axum::Router, body: serde_json::Value) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/play")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    (status, json)
+}
+
+// ============================================================================
+// Success cases — human move only (no bot)
+// ============================================================================
+
+#[tokio::test]
+async fn test_play_human_move_returns_200() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    let (status, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0 }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["api_version"], "v1");
+    assert_eq!(body["status"], "ongoing");
+    assert!(body["winner"].is_null());
+}
+
+#[tokio::test]
+async fn test_play_updates_yen_layout() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    let (_, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0 }),
+    )
+    .await;
+
+    // Layout should no longer be all dots — B played at position 0
+    let layout = body["yen"]["layout"].as_str().unwrap();
+    assert!(layout.contains('B'));
+}
+
+#[tokio::test]
+async fn test_play_advances_turn() {
+    let app = test_app();
+    let yen = empty_board_size3(); // turn = 0
+
+    let (_, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0 }),
+    )
+    .await;
+
+    // After player 0 (B) plays, turn should be 1 (R)
+    assert_eq!(body["yen"]["turn"], 1);
+}
+
+#[tokio::test]
+async fn test_play_position_last_cell() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    // Position 5 is the last cell in a size-3 board (0..5)
+    let (status, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 5 }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["api_version"], "v1");
+}
+
+// ============================================================================
+// Success cases — human move + bot response
+// ============================================================================
+
+#[tokio::test]
+async fn test_play_with_bot_returns_two_moves() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    let (status, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0, "bot_id": "random_bot" }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+
+    // Both B and R should have played — layout has both chars
+    let layout = body["yen"]["layout"].as_str().unwrap();
+    assert!(layout.contains('B'));
+    assert!(layout.contains('R'));
+}
+
+#[tokio::test]
+async fn test_play_with_bot_turn_is_back_to_human() {
+    let app = test_app();
+    let yen = empty_board_size3(); // turn = 0 (B)
+
+    let (_, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0, "bot_id": "random_bot" }),
+    )
+    .await;
+
+    // After human (0) and bot (1) both play, turn is back to 0
+    assert_eq!(body["yen"]["turn"], 0);
+}
+
+#[tokio::test]
+async fn test_play_without_bot_id_field() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    // bot_id is optional — omitting it should work fine
+    let (status, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0 }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "ongoing");
+}
+
+#[tokio::test]
+async fn test_play_with_null_bot_id() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    let (status, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0, "bot_id": null }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "ongoing");
+}
+
+#[tokio::test]
+async fn test_play_ongoing_when_no_winner_yet() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    let (_, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 2 }),
+    )
+    .await;
+
+    assert_eq!(body["status"], "ongoing");
+    assert!(body["winner"].is_null());
+}
+
+#[tokio::test]
+async fn test_play_winner_is_null_when_ongoing() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    let (_, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0 }),
+    )
+    .await;
+
+    assert!(body["winner"].is_null());
+}
+
+// ============================================================================
+// Error cases
+// ============================================================================
+
+#[tokio::test]
+async fn test_play_invalid_api_version() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v2/play")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({ "yen": yen, "position": 0 }))
+                        .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let error: ErrorResponse = serde_json::from_slice(&bytes).unwrap();
+
+    assert!(error.message.contains("Unsupported API version"));
+    assert_eq!(error.api_version, Some("v2".to_string()));
+}
+
+#[tokio::test]
+async fn test_play_occupied_cell_returns_error() {
+    let app = test_app();
+
+    // B already occupies position 0 (top cell) — trying to play there again
+    let yen = YEN::new(3, 1, vec!['B', 'R'], "B/../...".to_string());
+
+    let (_, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0 }),
+    )
+    .await;
+
+    assert!(body["message"]
+        .as_str()
+        .unwrap()
+        .contains("Invalid move"));
+}
+
+#[tokio::test]
+async fn test_play_game_already_over_returns_error() {
+    let app = test_app();
+
+    // Full winning board for B: B/BB/... — B wins
+    let yen = YEN::new(2, 0, vec!['B', 'R'], "B/BB".to_string());
+
+    let (_, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0 }),
+    )
+    .await;
+
+    assert!(body["message"]
+        .as_str()
+        .unwrap()
+        .contains("Game is already over"));
+}
+
+#[tokio::test]
+async fn test_play_unknown_bot_returns_error() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    let (_, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0, "bot_id": "nonexistent_bot" }),
+    )
+    .await;
+
+    assert!(body["message"]
+        .as_str()
+        .unwrap()
+        .contains("Bot not found"));
+    assert!(body["message"]
+        .as_str()
+        .unwrap()
+        .contains("nonexistent_bot"));
+}
+
+#[tokio::test]
+async fn test_play_invalid_yen_layout_returns_error() {
+    let app = test_app();
+
+    // Wrong number of rows for size 3 (4 rows instead of 3)
+    let body = serde_json::json!({
+        "yen": {
+            "size": 3,
+            "turn": 0,
+            "players": ["B", "R"],
+            "layout": "./../.../..."
+        },
+        "position": 0
+    });
+
+    let (_, response_body) = post_play(app, body).await;
+
+    assert!(response_body["message"]
+        .as_str()
+        .unwrap()
+        .contains("Invalid YEN"));
+}
+
+#[tokio::test]
+async fn test_play_invalid_json_returns_client_error() {
+    let app = test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/play")
+                .header("content-type", "application/json")
+                .body(Body::from("{ not valid json }"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(response.status().is_client_error());
+}
+
+#[tokio::test]
+async fn test_play_missing_content_type_returns_error() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/play")
+                // No content-type header
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({ "yen": yen, "position": 0 }))
+                        .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(response.status().is_client_error());
+}
+
+// ============================================================================
+// HTTP method tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_play_get_method_returns_405() {
+    let app = test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/play")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
+// ============================================================================
+// Response structure tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_play_response_contains_all_fields() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    let (_, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0 }),
+    )
+    .await;
+
+    assert!(body.get("api_version").is_some());
+    assert!(body.get("yen").is_some());
+    assert!(body.get("status").is_some());
+    assert!(body.get("winner").is_some());
+}
+
+#[tokio::test]
+async fn test_play_yen_response_contains_all_fields() {
+    let app = test_app();
+    let yen = empty_board_size3();
+
+    let (_, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0 }),
+    )
+    .await;
+
+    let yen_response = &body["yen"];
+    assert!(yen_response.get("size").is_some());
+    assert!(yen_response.get("turn").is_some());
+    assert!(yen_response.get("players").is_some());
+    assert!(yen_response.get("layout").is_some());
+}
+
+#[tokio::test]
+async fn test_play_preserves_board_size() {
+    let app = test_app();
+    let yen = empty_board_size3(); // size = 3
+
+    let (_, body) = post_play(
+        app,
+        serde_json::json!({ "yen": yen, "position": 0 }),
+    )
+    .await;
+
+    assert_eq!(body["yen"]["size"], 3);
+}

--- a/gateway/gateway-service.js
+++ b/gateway/gateway-service.js
@@ -48,6 +48,64 @@ app.get("/health", (req, res) => {
   res.json({ status: "Gateway up and running" });
 });
 
+// ─── API ─────────────────────────────
+const commonOptions = {
+  changeOrigin: true,
+  xfwd: true, // Adds X-Forwarded-For headers automatically
+  proxyTimeout: 5000, // Wait 5 seconds for the service to respond
+  onError: (err, req, res) => {
+    res.status(503).json({ error: "Service unreachable" });
+  },
+};
+
+// ─── Users Service Proxy ──────────────────────────────────────────────────────
+// Any request starting with /api/users will go to the Users service
+app.use(
+  "/api/users",
+  createProxyMiddleware({
+    ...commonOptions,
+    target: "http://users:3000",
+    // pathRewrite removes "/api/users" so the User service sees "/"
+    pathRewrite: { "^/api/users": "/api" },
+  }),
+);
+
+// ─── Gamey Service Proxy ──────────────────────────────────────────────────────
+// Any request starting with /api/gamey will go to the Gamey service
+app.use(
+  "/api/gamey",
+  createProxyMiddleware({
+    ...commonOptions,
+    target: "http://gamey:4000",
+    // pathRewrite removes "/api/gamey" so the Gamey service sees "/"
+    pathRewrite: { "^/api/gamey": "/api" },
+  }),
+);
+
+//Health of the api
+
+app.use(
+  "/api/health/users",
+  createProxyMiddleware({
+    ...commonOptions,
+    target: "http://users:3000",
+    // Rewrites /api/health/users to /health for the users service
+    pathRewrite: { "^/api/health/users": "/health" },
+  }),
+);
+
+app.use(
+  "/api/health/gamey",
+  createProxyMiddleware({
+    ...commonOptions,
+    target: "http://gamey:4000",
+    // Rewrites /api/health/gamey to /health for the gamey service
+    pathRewrite: { "^/api/health/gamey": "/health" },
+  }),
+);
+
+// ─────────────────────────────────────────────────────────
+
 app.listen(PORT, () => {
   console.log(`Gateway service listening on port ${PORT}`);
   console.log(`CORS allowed origin: ${ALLOWED_ORIGIN}`);

--- a/gateway/gateway-service.js
+++ b/gateway/gateway-service.js
@@ -4,6 +4,15 @@ const { createProxyMiddleware } = require("http-proxy-middleware");
 const app = express();
 const PORT = 8000;
 
+const commonOptions = {
+  changeOrigin: true,
+  xfwd: true, // Adds X-Forwarded-For headers automatically
+  proxyTimeout: 5000, // Wait 5 seconds for the service to respond
+  onError: (err, req, res) => {
+    res.status(503).json({ error: "Service unreachable" });
+  },
+};
+
 // ─── CORS ─────────────────────────────────────────────────────────────────────
 // Implemented with plain Express middleware so no extra npm package is needed. It was giving some problems
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || "*";
@@ -23,22 +32,24 @@ app.use((req, res, next) => {
   next();
 });
 
+//API GATEWAY: Routes and Proxies
+
 // ─── Proxy: Users service ─────────────────────────────────────────────────────
 app.use(
-  "/users",
+  "/api/users",
   createProxyMiddleware({
+    ...commonOptions,
     target: "http://users:3000",
-    changeOrigin: true,
     pathRewrite: { "^/users": "" },
   }),
 );
 
 // ─── Proxy: Gamey service ─────────────────────────────────────────────────────
 app.use(
-  "/gamey",
+  "/api/gamey",
   createProxyMiddleware({
+    ...commonOptions,
     target: "http://gamey:4000",
-    changeOrigin: true,
     pathRewrite: { "^/gamey": "" },
   }),
 );
@@ -47,64 +58,6 @@ app.use(
 app.get("/health", (req, res) => {
   res.json({ status: "Gateway up and running" });
 });
-
-// ─── API ─────────────────────────────
-const commonOptions = {
-  changeOrigin: true,
-  xfwd: true, // Adds X-Forwarded-For headers automatically
-  proxyTimeout: 5000, // Wait 5 seconds for the service to respond
-  onError: (err, req, res) => {
-    res.status(503).json({ error: "Service unreachable" });
-  },
-};
-
-// ─── Users Service Proxy ──────────────────────────────────────────────────────
-// Any request starting with /api/users will go to the Users service
-app.use(
-  "/api/users",
-  createProxyMiddleware({
-    ...commonOptions,
-    target: "http://users:3000",
-    // pathRewrite removes "/api/users" so the User service sees "/"
-    pathRewrite: { "^/api/users": "/api" },
-  }),
-);
-
-// ─── Gamey Service Proxy ──────────────────────────────────────────────────────
-// Any request starting with /api/gamey will go to the Gamey service
-app.use(
-  "/api/gamey",
-  createProxyMiddleware({
-    ...commonOptions,
-    target: "http://gamey:4000",
-    // pathRewrite removes "/api/gamey" so the Gamey service sees "/"
-    pathRewrite: { "^/api/gamey": "/api" },
-  }),
-);
-
-//Health of the api
-
-app.use(
-  "/api/health/users",
-  createProxyMiddleware({
-    ...commonOptions,
-    target: "http://users:3000",
-    // Rewrites /api/health/users to /health for the users service
-    pathRewrite: { "^/api/health/users": "/health" },
-  }),
-);
-
-app.use(
-  "/api/health/gamey",
-  createProxyMiddleware({
-    ...commonOptions,
-    target: "http://gamey:4000",
-    // Rewrites /api/health/gamey to /health for the gamey service
-    pathRewrite: { "^/api/health/gamey": "/health" },
-  }),
-);
-
-// ─────────────────────────────────────────────────────────
 
 app.listen(PORT, () => {
   console.log(`Gateway service listening on port ${PORT}`);

--- a/gateway/gateway-service.js
+++ b/gateway/gateway-service.js
@@ -6,8 +6,6 @@ const PORT = 8000;
 
 const commonOptions = {
   changeOrigin: true,
-  xfwd: true, // Adds X-Forwarded-For headers automatically
-  proxyTimeout: 5000, // Wait 5 seconds for the service to respond
   onError: (err, req, res) => {
     res.status(503).json({ error: "Service unreachable" });
   },
@@ -40,7 +38,7 @@ app.use(
   createProxyMiddleware({
     ...commonOptions,
     target: "http://users:3000",
-    pathRewrite: { "^/users": "" },
+    pathRewrite: { "^/api/users": "" },
   }),
 );
 
@@ -50,7 +48,7 @@ app.use(
   createProxyMiddleware({
     ...commonOptions,
     target: "http://gamey:4000",
-    pathRewrite: { "^/gamey": "" },
+    pathRewrite: { "^/api/gamey": "" },
   }),
 );
 

--- a/users/users-service.js
+++ b/users/users-service.js
@@ -44,7 +44,7 @@ app.post("/createuser", async (req, res) => {
       email: email || `${username}@example.com`,
     });
     const savedUser = await newUser.save();
-    
+
     const formattedDate = savedUser.createdAt.toLocaleString("es-ES", {
       timeZone: "Europe/Madrid",
       day: "2-digit",
@@ -70,10 +70,10 @@ app.post("/createuser", async (req, res) => {
   }
 });
 
-app.delete('/deleteuser/:username', async (req, res) => {
-  const usernameParam = String(req.params.username); 
+app.delete("/deleteuser/:username", async (req, res) => {
+  const usernameParam = String(req.params.username);
   try {
-    const result = await User.deleteOne({ name: { $eq: usernameParam } }); 
+    const result = await User.deleteOne({ name: { $eq: usernameParam } });
     if (result.deletedCount === 1) {
       res.json({ message: `User ${usernameParam} deleted successfully!` });
     } else {
@@ -83,6 +83,17 @@ app.delete('/deleteuser/:username', async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 });
+
+//API endpoints (UNDER DEVELOPMENT)
+app.get("/api/play", (req, res) => {
+  res.json({ message: "[UNDER DEVELOPMENT]: User is playing!" });
+});
+
+app.post("/api/login", (req, res) => {
+  res.json({ status: "[UNDER DEVELOPMENT]: Users is logged in" });
+});
+
+//API END
 
 async function startServer() {
   try {

--- a/webapp/src/GameBoard.tsx
+++ b/webapp/src/GameBoard.tsx
@@ -206,7 +206,7 @@ export default function GameBoard({ onBack }: { onBack: () => void }) {
         const yen = buildYEN(afterPlayer, 1, boardSize);
 
         const res = await fetch(
-          `${API_GATEWAY_URL}/gamey/${GAMEY_API_VERSION}/ybot/choose/${BOT_IDENTIFIER}`,
+          `${API_GATEWAY_URL}/api/gamey/${GAMEY_API_VERSION}/ybot/choose/${BOT_IDENTIFIER}`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/webapp/src/RegisterForm.tsx
+++ b/webapp/src/RegisterForm.tsx
@@ -30,7 +30,7 @@ const RegisterForm: React.FC<Props> = ({ onRegistered }) => {
 
     try {
       const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
-      const res = await fetch(`${API_URL}/users/createuser`, {
+      const res = await fetch(`${API_URL}/api/users/createuser`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
# 🎮 GameY Bot API — `play` endpoint & gateway routing
 
## 📋 Overview
 
This PR adds a new `/play` endpoint to the `gamey` bot server and ensures all game-related API traffic is properly routed through the API gateway. The `gamey` service is no longer exposed publicly — all access goes through `gateway`.


> [!IMPORTANT]
>  The `gateway` now its a unified API, all endpoints are `/api`. The `webapp` is another consumer of the API.
 
---
> [!NOTE]
> Closes #48  
---
 
## 🧩 What changed
 
### `gamey` — `bot_server/play.rs` (new file)
 
New stateless endpoint that applies a player move to a game state and optionally triggers a bot response in the same request.
 
The game state lives entirely on the client side as a **YEN object** (Y Exchange Notation). The server never stores anything between requests.
 
**Flow:**
```
Client sends YEN + position
       ↓
Server reconstructs GameY from YEN
       ↓
Server applies human move at position
       ↓
If bot_id provided → bot plays automatically
       ↓
Server returns updated YEN + game status
```
 
### `gamey` — `bot_server/mod.rs` (modified)
 
Added `play` module and registered the new route:
 
```rust
pub mod play;
 
pub fn create_router(state: AppState) -> axum::Router {
    axum::Router::new()
        .route("/status", axum::routing::get(status))
        .route("/{api_version}/ybot/choose/{bot_id}", axum::routing::post(choose::choose))
        .route("/{api_version}/play", axum::routing::post(play::play)) // ← new
        .layer(CorsLayer::permissive())
        .with_state(state)
}
```
 
### `gateway` — `gateway-service.js` (modified)
 
Changed the proxy route for the `gamey` and `users` service. The gateway strips `/api/gamey` and `/api/users` and forwards the rest to the internal respective container. 

Example with the `/api/gamey`:
 
```js
app.use(
  "/api/gamey",
  createProxyMiddleware({
    ...commonOptions,
    target: "http://gamey:4000",
    pathRewrite: { "^/api/gamey": "" },
  }),
);
```
 
### `docker-compose.yml` (modified)
 
- `gamey` starts as normal the **server mode** via `CMD` in its Dockerfile
- `gamey` and `users` no longer expose ports publicly — only accessible within `monitor-net`
- Only the gateway (`8000`) is the public entry point for API traffic
 
```
Public ports:  80 (webapp)  8000 (gateway)  9090 (prometheus)  9091 (grafana)
Internal only: gamey:4000   users:3000       mongo:27017
```
 
---
 
## 🌐 API endpoints
 
All endpoints are accessible through the gateway at `http://localhost:8000`.
 
| Method | Path | Description |
|--------|------|-------------|
| `GET`  | `/api/gamey/status` | Health check |
| `POST` | `/api/gamey/v1/ybot/choose/{bot_id}` | Ask a bot to choose a move |
| `POST` | `/api/gamey/v1/play` | Apply a move and optionally get bot response |
 
---
 
## 🧪 Testing with Postman
 
> All requests go to `http://localhost:8000`. Make sure the stack is up with `docker compose up`.
 
### ✅ 1. Health check
 
```
GET http://localhost:8000/api/gamey/status
```
 
Expected response:
```
OK
```
 
---
 
### 🤖 2. Ask the bot to choose a move
 
```
POST http://localhost:8000/api/gamey/v1/ybot/choose/random_bot
Content-Type: application/json
```
 
```json
{
  "size": 3,
  "turn": 0,
  "players": ["B", "R"],
  "layout": "./../..."
}
```
 
Expected response:
```json
{
  "api_version": "v1",
  "bot_id": "random_bot",
  "coords": { "x": 0, "y": 1, "z": 1 }
}
```
 
---
 
### 🎯 3. Play a move (human vs human, no bot)
 
```
POST http://localhost:8000/api/gamey/v1/play
Content-Type: application/json
```
 
```json
{
  "yen": {
    "size": 3,
    "turn": 0,
    "players": ["B", "R"],
    "layout": "./../..."
  },
  "position": 0
}
```
 
Expected response:
```json
{
  "api_version": "v1",
  "yen": {
    "size": 3,
    "turn": 1,
    "players": ["B", "R"],
    "layout": "B/../..."
  },
  "status": "ongoing",
  "winner": null
}
```
 
---
 
### 🏆 4. Play until someone wins
 
Use this sequence step by step. **Copy the `yen` from each response into the next request.**
 
> Board index reference for size 3:
> ```
>       0
>     1   2
>   3   4   5
> ```
 
**Step 1 — B plays position 0:**
```json
{
  "yen": { "size": 3, "turn": 0, "players": ["B","R"], "layout": "./../..." },
  "position": 0
}
```
 
**Step 2 — R plays position 5** *(copy yen from step 1 response)*:
```json
{
  "yen": { ...yen from previous response... },
  "position": 5
}
```
 
**Step 3 — B plays position 1** *(copy yen from step 2 response)*:
```json
{
  "yen": { ...yen from previous response... },
  "position": 1
}
```
 
**Step 4 — R plays position 4** *(copy yen from step 3 response)*:
```json
{
  "yen": { ...yen from previous response... },
  "position": 4
}
```
 
**Step 5 — B plays position 3 and wins 🎉** *(copy yen from step 4 response)*:
```json
{
  "yen": { ...yen from previous response... },
  "position": 3
}
```
 
Expected final response:
```json
{
  "api_version": "v1",
  "yen": { ... },
  "status": "finished",
  "winner": 0
}
```
 
B wins by connecting positions `0 → 1 → 3`, which together touch all three sides of the triangle. ✅
 
---
 
## ❌ Error cases
 
### Wrong API version → `400`
```
POST http://localhost:8000/api/gamey/v2/play
```
```json
{
  "api_version": "v2",
  "bot_id": null,
  "message": "Unsupported API version: v2. Supported version is v1"
}
```
 
### Occupied cell → `400`
```json
{
  "message": "Invalid move: Player 0 tries to place a stone on an occupied position: (2, 0, 0)"
}
```
 
### Bot not found → `400`
```json
{
  "api_version": "v1",
  "bot_id": "super_bot",
  "message": "Bot not found: super_bot, available bots: [random_bot]"
}
```
 
---
 
## 🏗️ Architecture
 
```
Internet
   │
   ▼
gateway:8000  (/api/gamey/*)
   │  strips /api/gamey prefix
   ▼
gamey:4000  (internal, monitor-net only)
   │  reconstructs GameY from YEN
   ▼
core/game.rs  (pure game logic, no HTTP)
```