### PR TITLE
🚀 feat/API

### DIFF
--- a/gamey/Cargo.lock
+++ b/gamey/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1399,6 +1400,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/gamey/Cargo.toml
+++ b/gamey/Cargo.toml
@@ -36,6 +36,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tokio = { version = "1.0", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors"] }
+urlencoding = "2.1.3"
 
 
 [dev-dependencies]

--- a/gamey/src/bot_server/mod.rs
+++ b/gamey/src/bot_server/mod.rs
@@ -43,7 +43,7 @@ pub fn create_router(state: AppState) -> axum::Router {
             "/{api_version}/ybot/choose/{bot_id}",
             axum::routing::post(choose::choose),
         )
-        .route("/{api_version}/play", axum::routing::post(play::play))
+        .route("/{api_version}/play", axum::routing::get(play::play))
         .layer(CorsLayer::permissive())
         .with_state(state)
 }

--- a/gamey/src/bot_server/play.rs
+++ b/gamey/src/bot_server/play.rs
@@ -1,91 +1,81 @@
-use crate::{Coordinates, GameY, GameStatus, Movement, YEN, 
-            check_api_version, error::ErrorResponse, state::AppState};
-use axum::{Json, extract::{Path, State}};
+use crate::{Coordinates, GameY, YEN, error::ErrorResponse, state::AppState};
+use axum::{Json, extract::{Query, State}};
 use serde::{Deserialize, Serialize};
 
+/// We define the query parameters expected by the competition.
+/// The 'position' field arrives as a URL-encoded JSON string.
 #[derive(Deserialize)]
-pub struct PlayParams {
-    pub api_version: String,
-}
-
-#[derive(Deserialize)]
-pub struct PlayRequest {
-    pub yen: YEN,
-    pub position: u32,
+pub struct PlayQuery {
+    pub position: String,
     pub bot_id: Option<String>,
 }
 
+/// We represent the bot's decision using an untagged enum.
+/// This allows the JSON output to switch between "coords" and "action" 
+/// formats automatically to meet the competition requirements.
 #[derive(Serialize)]
-pub struct PlayResponse {
-    pub api_version: String,
-    pub yen: YEN,
-    pub status: String,   // "ongoing" | "finished"
-    pub winner: Option<u32>,
+#[serde(untagged)]
+pub enum BotResponse {
+    Movement { coords: Coordinates },
+    Action { action: String },
 }
 
+/// GET endpoint that takes a board state 
+/// and returns the bot's next calculated move.
 #[axum::debug_handler]
 pub async fn play(
     State(state): State<AppState>,
-    Path(params): Path<PlayParams>,
-    Json(body): Json<PlayRequest>,
-) -> Result<Json<PlayResponse>, Json<ErrorResponse>> {
-    check_api_version(&params.api_version)?;
-
-    let mut game = GameY::try_from(body.yen).map_err(|e| {
+    Query(query): Query<PlayQuery>,
+) -> Result<Json<BotResponse>, Json<ErrorResponse>> {
+    
+    // We attempt to parse the 'position' query string into our YEN format.
+    let yen: YEN = serde_json::from_str(&query.position).map_err(|e| {
         Json(ErrorResponse::error(
-            &format!("Invalid YEN: {}", e),
-            Some(params.api_version.clone()),
+            &format!("Invalid YEN JSON: {}", e),
             None,
+            query.bot_id.clone(),
         ))
     })?;
 
-    // Apply the human move
-    let next = game.next_player().ok_or_else(|| {
+    // We convert the YEN representation into our internal GameY logic.
+    let game = GameY::try_from(yen).map_err(|e| {
         Json(ErrorResponse::error(
+            &format!("Invalid game state: {}", e),
+            None,
+            query.bot_id.clone(),
+        ))
+    })?;
+
+    // Check if the game has already concluded.
+    if game.check_game_over() {
+        return Err(Json(ErrorResponse::error(
             "Game is already over",
-            Some(params.api_version.clone()),
             None,
-        ))
-    })?;
-
-    let coords = Coordinates::from_index(body.position, game.board_size());
-    game.add_move(Movement::Placement { player: next, coords })
-        .map_err(|e| Json(ErrorResponse::error(
-            &format!("Invalid move: {}", e),
-            Some(params.api_version.clone()),
-            None,
-        )))?;
-
-    // If bot_id provided and game still ongoing, bot plays
-    if let Some(bot_id) = &body.bot_id {
-        if !game.check_game_over() {
-            let bot = state.bots().find(bot_id).ok_or_else(|| {
-                Json(ErrorResponse::error(
-                    &format!("Bot not found: {}", bot_id),
-                    Some(params.api_version.clone()),
-                    Some(bot_id.clone()),
-                ))
-            })?;
-
-            if let Some(bot_coords) = bot.choose_move(&game) {
-                let bot_player = game.next_player().unwrap();
-                game.add_move(Movement::Placement {
-                    player: bot_player,
-                    coords: bot_coords,
-                }).ok();
-            }
-        }
+            query.bot_id.clone(),
+        )));
     }
 
-    let (status, winner) = match game.status() {
-        GameStatus::Finished { winner } => ("finished".to_string(), Some(winner.id())),
-        GameStatus::Ongoing { .. }      => ("ongoing".to_string(),  None),
-    };
+    let bot_id = query.bot_id.unwrap_or_else(|| "heuristic_bot".to_string());
+    let bot = state.bots().find(&bot_id).ok_or_else(|| {
+        Json(ErrorResponse::error(
+            &format!("Bot not found: {}", bot_id),
+            None,
+            Some(bot_id.clone()),
+        ))
+    })?;
 
-    Ok(Json(PlayResponse {
-        api_version: params.api_version,
-        yen: (&game).into(),
-        status,
-        winner,
-    }))
+    // We ask our bot to choose the best move based on the provided state.
+    // Since we are using barycentric coordinates, our 'Coordinates' struct 
+    // already contains the necessary x, y, and z values.
+    match bot.choose_move(&game) {
+        Some(coords) => {
+            // We return the movement coordinates as the primary response.
+            Ok(Json(BotResponse::Movement { coords }))
+        }
+        None => {
+            // If our bot determines it must swap or resign, we handle that here.
+            // For now, if no move is found, we treat it as an error or a resignation.
+            Ok(Json(BotResponse::Action { action: "resign".to_string() }))
+        }
+    }
 }

--- a/gamey/src/bot_server/play.rs
+++ b/gamey/src/bot_server/play.rs
@@ -2,8 +2,7 @@ use crate::{Coordinates, GameY, YEN, error::ErrorResponse, state::AppState};
 use axum::{Json, extract::{Query, State}};
 use serde::{Deserialize, Serialize};
 
-/// We define the query parameters expected by the competition.
-/// The 'position' field arrives as a URL-encoded JSON string.
+/// Query parameters expected (position YEN & [optional] bot_id).
 #[derive(Deserialize)]
 pub struct PlayQuery {
     pub position: String,
@@ -28,7 +27,7 @@ pub async fn play(
     Query(query): Query<PlayQuery>,
 ) -> Result<Json<BotResponse>, Json<ErrorResponse>> {
     
-    // We attempt to parse the 'position' query string into our YEN format.
+    // Parsing the position query string into our YEN format.
     let yen: YEN = serde_json::from_str(&query.position).map_err(|e| {
         Json(ErrorResponse::error(
             &format!("Invalid YEN JSON: {}", e),
@@ -37,7 +36,8 @@ pub async fn play(
         ))
     })?;
 
-    // We convert the YEN representation into our internal GameY logic.
+    // Convert the YEN representation into our internal GameY logic.
+    // Try form function in game.rs
     let game = GameY::try_from(yen).map_err(|e| {
         Json(ErrorResponse::error(
             &format!("Invalid game state: {}", e),
@@ -55,6 +55,7 @@ pub async fn play(
         )));
     }
 
+    // bot_id is optional, default to "heuristic_bot" if not provided.
     let bot_id = query.bot_id.unwrap_or_else(|| "heuristic_bot".to_string());
     let bot = state.bots().find(&bot_id).ok_or_else(|| {
         Json(ErrorResponse::error(
@@ -64,16 +65,15 @@ pub async fn play(
         ))
     })?;
 
-    // We ask our bot to choose the best move based on the provided state.
-    // Since we are using barycentric coordinates, our 'Coordinates' struct 
-    // already contains the necessary x, y, and z values.
+    // Ask the bot to choose the best move based on the provided state.
     match bot.choose_move(&game) {
         Some(coords) => {
             // We return the movement coordinates as the primary response.
             Ok(Json(BotResponse::Movement { coords }))
         }
         None => {
-            // If our bot determines it must swap or resign, we handle that here.
+            // Swap or resign actions would be handled here
+
             // For now, if no move is found, we treat it as an error or a resignation.
             Ok(Json(BotResponse::Action { action: "resign".to_string() }))
         }

--- a/gamey/tests/play_tests.rs
+++ b/gamey/tests/play_tests.rs
@@ -119,6 +119,71 @@ async fn test_method_not_allowed() {
     assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
 }
 
+#[tokio::test]
+async fn test_invalid_yen_json() {
+    let app = test_app();
+    
+    // Malformed JSON string (missing a closing brace)
+    let malformed_json = "{\"size\":3, \"turn\":0"; 
+    let uri = format!("/v1/play?position={}", urlencoding::encode(malformed_json));
+
+    let response = app.oneshot(
+        Request::builder().method("GET").uri(uri).body(Body::empty()).unwrap()
+    ).await.unwrap();
+
+    // play.rs returns 200 OK even for errors
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+    
+    // Verify the error message matches the 'Invalid YEN JSON' pattern
+    assert!(body["message"].as_str().unwrap().contains("Invalid YEN JSON"));
+}
+
+#[tokio::test]
+async fn test_invalid_game_state() {
+    let app = test_app();
+    
+    // Valid JSON, but the layout is wrong for a size 3 board (too many segments)
+    let yen = YEN::new(3, 0, vec!['B', 'R'], "B/B/B/B/B".to_string());
+    let yen_json = serde_json::to_string(&yen).unwrap();
+
+    let uri = format!("/v1/play?position={}", urlencoding::encode(&yen_json));
+
+    let response = app.oneshot(
+        Request::builder().method("GET").uri(uri).body(Body::empty()).unwrap()
+    ).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+    
+    // Verify the error message matches the 'Invalid game state' pattern
+    assert!(body["message"].as_str().unwrap().contains("Invalid game state"));
+}
+
+#[tokio::test]
+async fn test_bot_not_found() {
+    let app = test_app();
+    let yen = YEN::new(3, 0, vec!['B', 'R'], "./../...".to_string());
+    let yen_json = serde_json::to_string(&yen).unwrap();
+
+    // Use a bot_id that is not in the registry
+    let uri = format!("/v1/play?position={}&bot_id=unknown_bot", urlencoding::encode(&yen_json));
+
+    let response = app.oneshot(
+        Request::builder().method("GET").uri(uri).body(Body::empty()).unwrap()
+    ).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+    
+    // Matches the 'Bot not found' error logic
+    assert!(body["message"].as_str().unwrap().contains("Bot not found: unknown_bot"));
+    assert_eq!(body["bot_id"], "unknown_bot");
+}
+
 //Extra
 #[tokio::test]
 async fn test_play_normal_move_returns_coords() {

--- a/gamey/tests/play_tests.rs
+++ b/gamey/tests/play_tests.rs
@@ -2,11 +2,17 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
-use gamey::{YBotRegistry, YEN, create_default_state, create_router, state::AppState, RandomBot, ErrorResponse};
+use gamey::{YEN, create_default_state, create_router};
 use http_body_util::BodyExt;
 use serde_json::Value;
-use std::sync::Arc;
 use tower::ServiceExt;
+
+// ============================================================================
+// CONFIGURATION
+// ============================================================================
+
+// Updated to match your working Postman URL
+const PATH_PREFIX: &str = "/v1";
 
 // ============================================================================
 // Helpers
@@ -20,14 +26,22 @@ fn empty_board_size3() -> YEN {
     YEN::new(3, 0, vec!['B', 'R'], "./../...".to_string())
 }
 
-async fn post_play(app: axum::Router, body: serde_json::Value) -> (StatusCode, Value) {
+/// Robust helper for GET requests to the play endpoint
+async fn get_play(app: axum::Router, yen: &YEN, bot_id: Option<&str>) -> (StatusCode, Value) {
+    let yen_json = serde_json::to_string(yen).unwrap();
+    
+    let mut uri = format!("{}/play?position={}", PATH_PREFIX, urlencoding::encode(&yen_json));
+    
+    if let Some(id) = bot_id {
+        uri.push_str(&format!("&bot_id={}", urlencoding::encode(id)));
+    }
+    
     let response = app
         .oneshot(
             Request::builder()
-                .method("POST")
-                .uri("/v1/play")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .method("GET")
+                .uri(&uri)
+                .body(Body::empty())
                 .unwrap(),
         )
         .await
@@ -35,402 +49,143 @@ async fn post_play(app: axum::Router, body: serde_json::Value) -> (StatusCode, V
 
     let status = response.status();
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
-    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    
+    // Safety: If 404 or empty, return Null instead of panicking on JSON parse
+    if bytes.is_empty() {
+        return (status, Value::Null);
+    }
+
+    let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
     (status, json)
 }
 
 // ============================================================================
-// Success cases — human move only (no bot)
+// Tests
 // ============================================================================
 
 #[tokio::test]
-async fn test_play_human_move_returns_200() {
+async fn test_get_play_success() {
+    let app = test_app();
+    let yen = empty_board_size3();
+    let (status, body) = get_play(app, &yen, Some("heuristic_bot")).await;
+
+    assert_eq!(status, StatusCode::OK, "Check if PATH_PREFIX matches your router configuration");
+    assert!(body.get("coords").is_some());
+}
+
+#[tokio::test]
+async fn test_get_play_no_bot_id_defaults_to_heuristic() {
     let app = test_app();
     let yen = empty_board_size3();
 
-    let (status, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0 }),
-    )
-    .await;
+    // Passing None simulates the absence of the &bot_id= parameter in the URL
+    let (status, body) = get_play(app, &yen, None).await;
 
+    // It should succeed (200) because the code defaults to "heuristic_bot"
+    assert_eq!(status, StatusCode::OK, "Should default to heuristic_bot and return 200");
+    assert!(body.get("coords").is_some(), "Response should contain coordinates from the default bot");
+}
+
+#[tokio::test]
+async fn test_get_play_game_over_returns_error_message() {
+    let app = test_app();
+    
+    // Use the layout that works in Postman: "B/RR/BBB"
+    // Turn 5 (or any number) is fine as long as the layout is complete
+    let yen = YEN::new(3, 5, vec!['B', 'R'], "B/RR/BBB".to_string());
+
+    let (status, body) = get_play(app, &yen, Some("heuristic_bot")).await;
+
+    // Based on your play.rs, this returns 200 OK with an error JSON
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["api_version"], "v1");
-    assert_eq!(body["status"], "ongoing");
-    assert!(body["winner"].is_null());
+    
+    // Ensure we are checking the "message" field
+    assert!(
+        body["message"].as_str().expect("Body should have a message field").contains("Game is already over"),
+        "Body was: {:?}", body
+    );
 }
 
 #[tokio::test]
-async fn test_play_updates_yen_layout() {
+async fn test_method_not_allowed() {
     let app = test_app();
-    let yen = empty_board_size3();
-
-    let (_, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0 }),
-    )
-    .await;
-
-    // Layout should no longer be all dots — B played at position 0
-    let layout = body["yen"]["layout"].as_str().unwrap();
-    assert!(layout.contains('B'));
-}
-
-#[tokio::test]
-async fn test_play_advances_turn() {
-    let app = test_app();
-    let yen = empty_board_size3(); // turn = 0
-
-    let (_, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0 }),
-    )
-    .await;
-
-    // After player 0 (B) plays, turn should be 1 (R)
-    assert_eq!(body["yen"]["turn"], 1);
-}
-
-#[tokio::test]
-async fn test_play_position_last_cell() {
-    let app = test_app();
-    let yen = empty_board_size3();
-
-    // Position 5 is the last cell in a size-3 board (0..5)
-    let (status, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 5 }),
-    )
-    .await;
-
-    assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["api_version"], "v1");
-}
-
-// ============================================================================
-// Success cases — human move + bot response
-// ============================================================================
-
-#[tokio::test]
-async fn test_play_with_bot_returns_two_moves() {
-    let app = test_app();
-    let yen = empty_board_size3();
-
-    let (status, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0, "bot_id": "random_bot" }),
-    )
-    .await;
-
-    assert_eq!(status, StatusCode::OK);
-
-    // Both B and R should have played — layout has both chars
-    let layout = body["yen"]["layout"].as_str().unwrap();
-    assert!(layout.contains('B'));
-    assert!(layout.contains('R'));
-}
-
-#[tokio::test]
-async fn test_play_with_bot_turn_is_back_to_human() {
-    let app = test_app();
-    let yen = empty_board_size3(); // turn = 0 (B)
-
-    let (_, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0, "bot_id": "random_bot" }),
-    )
-    .await;
-
-    // After human (0) and bot (1) both play, turn is back to 0
-    assert_eq!(body["yen"]["turn"], 0);
-}
-
-#[tokio::test]
-async fn test_play_without_bot_id_field() {
-    let app = test_app();
-    let yen = empty_board_size3();
-
-    // bot_id is optional — omitting it should work fine
-    let (status, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0 }),
-    )
-    .await;
-
-    assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["status"], "ongoing");
-}
-
-#[tokio::test]
-async fn test_play_with_null_bot_id() {
-    let app = test_app();
-    let yen = empty_board_size3();
-
-    let (status, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0, "bot_id": null }),
-    )
-    .await;
-
-    assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["status"], "ongoing");
-}
-
-#[tokio::test]
-async fn test_play_ongoing_when_no_winner_yet() {
-    let app = test_app();
-    let yen = empty_board_size3();
-
-    let (_, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 2 }),
-    )
-    .await;
-
-    assert_eq!(body["status"], "ongoing");
-    assert!(body["winner"].is_null());
-}
-
-#[tokio::test]
-async fn test_play_winner_is_null_when_ongoing() {
-    let app = test_app();
-    let yen = empty_board_size3();
-
-    let (_, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0 }),
-    )
-    .await;
-
-    assert!(body["winner"].is_null());
-}
-
-// ============================================================================
-// Error cases
-// ============================================================================
-
-#[tokio::test]
-async fn test_play_invalid_api_version() {
-    let app = test_app();
-    let yen = empty_board_size3();
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v2/play")
-                .header("content-type", "application/json")
-                .body(Body::from(
-                    serde_json::to_string(&serde_json::json!({ "yen": yen, "position": 0 }))
-                        .unwrap(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    let bytes = response.into_body().collect().await.unwrap().to_bytes();
-    let error: ErrorResponse = serde_json::from_slice(&bytes).unwrap();
-
-    assert!(error.message.contains("Unsupported API version"));
-    assert_eq!(error.api_version, Some("v2".to_string()));
-}
-
-#[tokio::test]
-async fn test_play_occupied_cell_returns_error() {
-    let app = test_app();
-
-    // B already occupies position 0 (top cell) — trying to play there again
-    let yen = YEN::new(3, 1, vec!['B', 'R'], "B/../...".to_string());
-
-    let (_, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0 }),
-    )
-    .await;
-
-    assert!(body["message"]
-        .as_str()
-        .unwrap()
-        .contains("Invalid move"));
-}
-
-#[tokio::test]
-async fn test_play_game_already_over_returns_error() {
-    let app = test_app();
-
-    // Full winning board for B: B/BB/... — B wins
-    let yen = YEN::new(2, 0, vec!['B', 'R'], "B/BB".to_string());
-
-    let (_, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0 }),
-    )
-    .await;
-
-    assert!(body["message"]
-        .as_str()
-        .unwrap()
-        .contains("Game is already over"));
-}
-
-#[tokio::test]
-async fn test_play_unknown_bot_returns_error() {
-    let app = test_app();
-    let yen = empty_board_size3();
-
-    let (_, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0, "bot_id": "nonexistent_bot" }),
-    )
-    .await;
-
-    assert!(body["message"]
-        .as_str()
-        .unwrap()
-        .contains("Bot not found"));
-    assert!(body["message"]
-        .as_str()
-        .unwrap()
-        .contains("nonexistent_bot"));
-}
-
-#[tokio::test]
-async fn test_play_invalid_yen_layout_returns_error() {
-    let app = test_app();
-
-    // Wrong number of rows for size 3 (4 rows instead of 3)
-    let body = serde_json::json!({
-        "yen": {
-            "size": 3,
-            "turn": 0,
-            "players": ["B", "R"],
-            "layout": "./../.../..."
-        },
-        "position": 0
-    });
-
-    let (_, response_body) = post_play(app, body).await;
-
-    assert!(response_body["message"]
-        .as_str()
-        .unwrap()
-        .contains("Invalid YEN"));
-}
-
-#[tokio::test]
-async fn test_play_invalid_json_returns_client_error() {
-    let app = test_app();
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/play")
-                .header("content-type", "application/json")
-                .body(Body::from("{ not valid json }"))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert!(response.status().is_client_error());
-}
-
-#[tokio::test]
-async fn test_play_missing_content_type_returns_error() {
-    let app = test_app();
-    let yen = empty_board_size3();
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/play")
-                // No content-type header
-                .body(Body::from(
-                    serde_json::to_string(&serde_json::json!({ "yen": yen, "position": 0 }))
-                        .unwrap(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert!(response.status().is_client_error());
-}
-
-// ============================================================================
-// HTTP method tests
-// ============================================================================
-
-#[tokio::test]
-async fn test_play_get_method_returns_405() {
-    let app = test_app();
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("GET")
-                .uri("/v1/play")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = app.oneshot(
+        Request::builder()
+            .method("POST") // play is GET only
+            .uri(format!("{}/play", PATH_PREFIX))
+            .body(Body::empty()).unwrap(),
+    ).await.unwrap();
 
     assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
 }
 
-// ============================================================================
-// Response structure tests
-// ============================================================================
-
+//Extra
 #[tokio::test]
-async fn test_play_response_contains_all_fields() {
+async fn test_play_normal_move_returns_coords() {
     let app = test_app();
-    let yen = empty_board_size3();
+    let yen = YEN::new(3, 2, vec!['B', 'R'], "B/R./...".to_string());
+    let yen_json = serde_json::to_string(&yen).unwrap();
 
-    let (_, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0 }),
-    )
-    .await;
+    let uri = format!("/v1/play?position={}&bot_id=heuristic_bot", urlencoding::encode(&yen_json));
 
-    assert!(body.get("api_version").is_some());
-    assert!(body.get("yen").is_some());
-    assert!(body.get("status").is_some());
-    assert!(body.get("winner").is_some());
+    let response = app.oneshot(
+        Request::builder().method("GET").uri(uri).body(Body::empty()).unwrap()
+    ).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+    
+    // 1. Verify 'coords' exists
+    assert!(body.get("coords").is_some(), "Expected 'coords' property, got: {:?}", body);
+    
+    // 2. Verify the specific coordinate fields returned in Postman (x, y, z)
+    let coords = body.get("coords").unwrap();
+    assert!(coords.get("x").is_some(), "Missing 'x' in coords");
+    assert!(coords.get("y").is_some(), "Missing 'y' in coords");
+    assert!(coords.get("z").is_some(), "Missing 'z' in coords");
 }
 
 #[tokio::test]
-async fn test_play_yen_response_contains_all_fields() {
+async fn test_play_blue_winning_move() {
     let app = test_app();
-    let yen = empty_board_size3();
+    // Blue (B) is one move away from completing a vertical connection in a size 3 board
+    // Layout: B at top, B at middle-right. Bottom row is empty.
+    let yen = YEN::new(3, 4, vec!['B', 'R'], "B/.B/...".to_string());
+    let yen_json = serde_json::to_string(&yen).unwrap();
 
-    let (_, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0 }),
-    )
-    .await;
+    let uri = format!("/v1/play?position={}&bot_id=heuristic_bot", urlencoding::encode(&yen_json));
 
-    let yen_response = &body["yen"];
-    assert!(yen_response.get("size").is_some());
-    assert!(yen_response.get("turn").is_some());
-    assert!(yen_response.get("players").is_some());
-    assert!(yen_response.get("layout").is_some());
+    let response = app.oneshot(
+        Request::builder().method("GET").uri(uri).body(Body::empty()).unwrap()
+    ).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+    
+    // The bot should return a coordinate to attempt to complete the path
+    assert!(body.get("coords").is_some(), "Winning move should still return 'coords'");
 }
 
 #[tokio::test]
-async fn test_play_preserves_board_size() {
+async fn test_play_red_winning_move() {
     let app = test_app();
-    let yen = empty_board_size3(); // size = 3
+    // Red (R) is one move away from a horizontal connection
+    let yen = YEN::new(3, 4, vec!['B', 'R'], "./R./R..".to_string());
+    let yen_json = serde_json::to_string(&yen).unwrap();
 
-    let (_, body) = post_play(
-        app,
-        serde_json::json!({ "yen": yen, "position": 0 }),
-    )
-    .await;
+    let uri = format!("/v1/play?position={}&bot_id=heuristic_bot", urlencoding::encode(&yen_json));
 
-    assert_eq!(body["yen"]["size"], 3);
+    let response = app.oneshot(
+        Request::builder().method("GET").uri(uri).body(Body::empty()).unwrap()
+    ).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+    
+    // Ensure the untagged enum correctly serializes the movement
+    assert!(body.get("coords").is_some());
+    assert!(body.get("action").is_none(), "Should not return an action when a move is available");
 }


### PR DESCRIPTION
## Description: API Standards Compliance and Test Suite Refactor

This issue documents the transition of the `play` endpoint to meet project standards, specifically regarding HTTP method conventions and robust automated testing of the bot's movement logic.

### 🔄 Changes Implemented

#### 1. HTTP Method Standard Alignment
- **Changed `play` endpoint from `POST` to `GET`**: Aligned the endpoint with REST standards as the operation is idempotent and retrieves a calculated move based on the provided query state without modifying server-side resources.
- **Query Parameter Refactor**: Moved the `position` (YEN string) and `bot_id` from the request body to URL query parameters.

#### 2. API Logic Enhancements (`play.rs`)
- **Adapter Pattern Implementation**: `play.rs` acts as a strict adapter/controller.
- **Default Bot Logic**: Implemented fallback logic to `heuristic_bot` if no `bot_id` is provided in the request.
- **Untagged Response Handling**: Utilized `#[serde(untagged)]` on `BotResponse` to automatically switch between `coords` (Movement) and `action` (Resignation) JSON structures.
- **Pre-calculation Guards**: Integrated `game.check_game_over()` to return an error immediately if the board is already in a terminal state.

### 🧪 Testing & Validation

#### 1. Test Suite Fixes
- **Path Resolution**: Fixed `404 Not Found` errors in tests by aligning `PATH_PREFIX` with the `/{api_version}/play` router definition.
- **Status Code Synchronization**: Updated test assertions to expect `200 OK` for error responses (e.g., "Game is already over") to match the current `Result<Json, Json>` implementation in the Axum handler.
- **Coordinate Schema Validation**: Updated tests to verify the `x, y, z` coordinate structure returned by the bot instead of the previous `row, col` format.

#### 2. Verified Scenarios
| Test Case | Input Layout | Expected Output | Status |
| :--- | :--- | :--- | :--- |
| **Normal Move** | `B/R./...` | `200 OK` + `coords {x, y, z}` | ✅ Passed |
| **Default Bot** | (No bot_id) | `200 OK` (Uses heuristic) | ✅ Passed |
| **Game Over** | `B/RR/BBB` | `200 OK` + `"message": "Game is already over"` | ✅ Passed |
| **Invalid Bot** | `bot_id=fake` | `200 OK` + `"message": "Bot not found"` | ✅ Passed |
